### PR TITLE
Build a fast zsh plugin manager

### DIFF
--- a/bin/zpm
+++ b/bin/zpm
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# zpm - a fast, robust Zsh plugin manager
+# Requires: bash >= 4.3, curl, tar; optionally git, zsh
+
+set -Eeuo pipefail
+
+# Resolve script directory
+_zpm_script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+_zpm_root="$(cd "${_zpm_script_dir}/.." && pwd)"
+
+# Load libs
+source "${_zpm_root}/lib/zpm/common.sh"
+source "${_zpm_root}/lib/zpm/locks.sh"
+source "${_zpm_root}/lib/zpm/git.sh"
+source "${_zpm_root}/lib/zpm/plugins.sh"
+source "${_zpm_root}/lib/zpm/cli.sh"
+
+# Entry
+zpm_cli_dispatch "${1:-help}" "$@"

--- a/lib/zpm/cli.sh
+++ b/lib/zpm/cli.sh
@@ -1,0 +1,129 @@
+#!/usr/bin/env bash
+# shellcheck shell=bash
+
+# CLI dispatch for zpm
+
+zpm_usage() {
+  cat <<'USAGE'
+Usage: zpm <command> [options]
+
+Commands:
+  help                     Show this help
+  version                  Show version
+  path                     Show zpm home directory
+  doctor                   Check environment and dependencies
+  install [SPEC ...]       Install plugins (from args or plugins file)
+  update  [SPEC ...]       Update plugins (from args or plugins file)
+  list                     List installed plugins
+  init                     Print snippet to add to .zshrc
+
+Environment:
+  ZPM_HOME, ZPM_REPOS_DIR, ZPM_LOCKS_DIR, ZPM_PLUGINS_FILE, ZPM_JOBS, ZPM_COLOR
+
+Examples:
+  zpm install zsh-users/zsh-autosuggestions zsh-users/zsh-syntax-highlighting
+  zpm update
+  zpm init >> ~/.zshrc
+USAGE
+}
+
+zpm_cmd_version() { echo "zpm ${ZPM_VERSION}"; }
+
+zpm_cmd_path() { echo "${ZPM_HOME}"; }
+
+zpm_cmd_doctor() {
+  local ok=1
+  for c in bash curl tar; do
+    if ! is_command "$c"; then zpm_warn "Missing: $c"; ok=0; else zpm_info "Found: $c"; fi
+  done
+  if is_command git; then zpm_info "Found: git"; else zpm_warn "git not found (tarball fallback for GitHub only)"; fi
+  if is_command zsh; then zpm_info "Found: zsh"; else zpm_warn "zsh not found (loading in shell will be limited)"; fi
+  [[ $ok -eq 1 ]] || return 1
+}
+
+zpm_cmd_install() {
+  shift || true # shift off subcommand name from caller
+  local specs=()
+  if [[ $# -gt 0 ]]; then
+    specs=("$@")
+  else
+    if [[ -f "$ZPM_PLUGINS_FILE" ]]; then
+      mapfile -t specs < <(zpm_plugins_from_file "$ZPM_PLUGINS_FILE")
+    else
+      die "No specs given and plugins file not found: ${ZPM_PLUGINS_FILE}"
+    fi
+  fi
+  if [[ ${#specs[@]} -eq 0 ]]; then
+    zpm_info "Nothing to install"
+    return 0
+  fi
+  zpm_info "Installing ${#specs[@]} plugin(s) with concurrency ${ZPM_JOBS}"
+  zpm_parallel_each "${ZPM_JOBS}" zpm_install_one "${specs[@]}"
+}
+
+zpm_cmd_update() {
+  shift || true
+  local specs=()
+  if [[ $# -gt 0 ]]; then
+    specs=("$@")
+  else
+    # Build specs from installed layout
+    while IFS= read -r rel; do
+      local host owner name
+      host="${rel%%/*}"; local tmp=${rel#*/}; owner="${tmp%%/*}"; name="${tmp#*/}"
+      specs+=("https://${host}/${owner}/${name}.git")
+    done < <(zpm_list_installed)
+  fi
+  if [[ ${#specs[@]} -eq 0 ]]; then
+    zpm_info "Nothing to update"
+    return 0
+  fi
+  zpm_info "Updating ${#specs[@]} plugin(s) with concurrency ${ZPM_JOBS}"
+  zpm_parallel_each "${ZPM_JOBS}" zpm_update_one "${specs[@]}"
+}
+
+zpm_cmd_list() {
+  zpm_list_installed
+}
+
+zpm_cmd_init() {
+  cat <<'INIT'
+# zpm init - add this to your .zshrc
+# Load plugins installed under ZPM_HOME
+if [[ -z "$ZPM_HOME" ]]; then
+  if [[ -n "$XDG_CACHE_HOME" ]]; then ZPM_HOME="$XDG_CACHE_HOME/zpm"; else ZPM_HOME="$HOME/.cache/zpm"; fi
+fi
+if [[ -d "$ZPM_HOME/repos" ]]; then
+  # Update fpath for functions directories
+  for d in "$ZPM_HOME"/repos/*/*/*; do
+    if [[ -d "$d" ]]; then
+      [[ -d "$d/functions" ]] && fpath=("$d/functions" $fpath)
+      # Source plugin entrypoints
+      if [[ -f "$d/${PWD##*/}.plugin.zsh" ]]; then
+        source "$d/${PWD##*/}.plugin.zsh"
+      else
+        for f in "$d"/*.plugin.zsh(N) "$d"/*.zsh(N); do
+          [[ -f "$f" ]] && source "$f"
+        done
+      fi
+    fi
+  done
+fi
+unset d f
+INIT
+}
+
+zpm_cli_dispatch() {
+  local cmd="${1:-help}"
+  case "$cmd" in
+    help|-h|--help) zpm_usage ;;
+    version|--version) zpm_cmd_version ;;
+    path) zpm_cmd_path ;;
+    doctor) zpm_cmd_doctor ;;
+    install) zpm_cmd_install "$@" ;;
+    update) zpm_cmd_update "$@" ;;
+    list|ls) zpm_cmd_list ;;
+    init) zpm_cmd_init ;;
+    *) zpm_error "Unknown command: $cmd"; echo; zpm_usage; return 1 ;;
+  esac
+}

--- a/lib/zpm/common.sh
+++ b/lib/zpm/common.sh
@@ -1,0 +1,154 @@
+#!/usr/bin/env bash
+# shellcheck shell=bash
+
+# Core environment, logging, and utility helpers for zpm
+
+# Strict mode for robustness
+set -Eeuo pipefail
+
+# Defaults and directories
+: "${XDG_CACHE_HOME:=${HOME}/.cache}"
+: "${XDG_CONFIG_HOME:=${HOME}/.config}"
+: "${ZPM_HOME:=${XDG_CACHE_HOME}/zpm}"
+: "${ZPM_LOCKS_DIR:=${ZPM_HOME}/locks}"
+: "${ZPM_REPOS_DIR:=${ZPM_HOME}/repos}"
+: "${ZPM_PLUGINS_FILE:=${XDG_CONFIG_HOME}/zpm/plugins.txt}"
+: "${ZPM_DEBUG:=}"
+: "${ZPM_COLOR:=auto}"
+: "${ZPM_LOG_TIME:=auto}"
+: "${ZPM_LOCK_TIMEOUT:=60}"
+: "${ZPM_JOBS:=}"
+
+mkdir -p "${ZPM_HOME}" "${ZPM_LOCKS_DIR}" "${ZPM_REPOS_DIR}" || true
+
+# Determine concurrency
+if [[ -z "${ZPM_JOBS}" ]]; then
+  if command -v nproc >/dev/null 2>&1; then
+    ZPM_JOBS="$(nproc)"
+  elif command -v sysctl >/dev/null 2>&1; then
+    ZPM_JOBS="$(sysctl -n hw.ncpu 2>/dev/null || echo 4)"
+  else
+    ZPM_JOBS=4
+  fi
+fi
+if ! [[ "${ZPM_JOBS}" =~ ^[0-9]+$ ]] || [[ "${ZPM_JOBS}" -lt 1 ]]; then
+  ZPM_JOBS=4
+fi
+
+# Colors
+_zpm_is_tty() { [[ -t 1 ]]; }
+_zpm_use_color() {
+  case "${ZPM_COLOR}" in
+    always) return 0 ;;
+    never) return 1 ;;
+    auto|*) _zpm_is_tty ;;
+  esac
+}
+if _zpm_use_color; then
+  ZPM_CLR_RESET=$'\033[0m'
+  ZPM_CLR_DIM=$'\033[2m'
+  ZPM_CLR_RED=$'\033[31m'
+  ZPM_CLR_GREEN=$'\033[32m'
+  ZPM_CLR_YELLOW=$'\033[33m'
+  ZPM_CLR_BLUE=$'\033[34m'
+else
+  ZPM_CLR_RESET=""; ZPM_CLR_DIM=""; ZPM_CLR_RED=""; ZPM_CLR_GREEN=""; ZPM_CLR_YELLOW=""; ZPM_CLR_BLUE=""
+fi
+
+# Timestamp toggle
+_zpm_now() {
+  if [[ "${ZPM_LOG_TIME}" == "always" ]] || { [[ "${ZPM_LOG_TIME}" == "auto" ]] && ! _zpm_is_tty; }; then
+    date +"%H:%M:%S"
+  else
+    echo ""
+  fi
+}
+
+# Logging
+zpm_log() {
+  local level="$1"; shift
+  local color=""; local prefix="[$( _zpm_now )]"
+  case "$level" in
+    INFO) color="$ZPM_CLR_GREEN" ;;
+    WARN) color="$ZPM_CLR_YELLOW" ;;
+    ERROR) color="$ZPM_CLR_RED" ;;
+    DEBUG) color="$ZPM_CLR_BLUE" ;;
+    *) color="" ;;
+  esac
+  if [[ "$level" == "DEBUG" && -z "${ZPM_DEBUG}" ]]; then return 0; fi
+  if [[ -n "$prefix" ]]; then prefix="${prefix} "; fi
+  printf "%b%s%s%b %s%b\n" "$color" "$prefix" "$level" "$ZPM_CLR_RESET" "$*" "$ZPM_CLR_RESET" >&2
+}
+
+zpm_info() { zpm_log INFO "$@"; }
+zpm_warn() { zpm_log WARN "$@"; }
+zpm_error() { zpm_log ERROR "$@"; }
+zpm_debug() { zpm_log DEBUG "$@"; }
+
+die() { zpm_error "$*"; exit 1; }
+
+# Command helpers
+is_command() { command -v "$1" >/dev/null 2>&1; }
+require_cmd() { is_command "$1" || die "Required command not found: $1"; }
+
+# Temp directory helpers
+_zpm_tmp_dirs=()
+mktempdir() {
+  local t
+  t="$(mktemp -d 2>/dev/null || mktemp -d -t zpm)"
+  _zpm_tmp_dirs+=("$t")
+  echo "$t"
+}
+
+cleanup_tmpdirs() {
+  local t
+  for t in "${_zpm_tmp_dirs[@]:-}"; do
+    [[ -n "$t" && -d "$t" ]] && rm -rf "$t" || true
+  done
+}
+
+# Safe cleanup on exit and errors
+trap cleanup_tmpdirs EXIT
+
+# Concurrency helpers
+_have_wait_n=1
+if ! wait -n 2>/dev/null; then _have_wait_n=0; fi
+
+zpm_parallel_each() {
+  # Usage: zpm_parallel_each <concurrency> <function> <args...>
+  local concurrency="$1"; shift
+  local func="$1"; shift
+  local -a pids=()
+  local running=0
+  local item
+  if [[ "$concurrency" -lt 2 ]]; then
+    for item in "$@"; do "$func" "$item"; done
+    return 0
+  fi
+  for item in "$@"; do
+    "$func" "$item" &
+    pids+=("$!")
+    running=$((running+1))
+    if [[ $running -ge $concurrency ]]; then
+      if [[ $_have_wait_n -eq 1 ]]; then
+        wait -n || true
+        running=$((running-1))
+      else
+        wait "${pids[0]}" || true
+        pids=("${pids[@]:1}")
+        running=$((running-1))
+      fi
+    fi
+  done
+  wait || true
+}
+
+# Path utils
+zpm_repo_path() {
+  # host owner name -> path
+  local host="$1" owner="$2" name="$3"
+  echo "${ZPM_REPOS_DIR}/${host}/${owner}/${name}"
+}
+
+# Version
+ZPM_VERSION="0.1.0"

--- a/lib/zpm/git.sh
+++ b/lib/zpm/git.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+# shellcheck shell=bash
+
+# Git and tarball fallback operations
+
+zpm_git_available() { is_command git; }
+
+zpm_clone_shallow() {
+  # url dest [ref]
+  local url="$1" dest="$2" ref="${3:-}"
+  if zpm_git_available; then
+    local args=(clone --filter=blob:none --depth 1 --recurse-submodules --shallow-submodules)
+    if [[ -n "$ref" ]]; then
+      # We try as branch/tag. If not, we handle after clone.
+      args+=(--branch "$ref" --single-branch)
+    fi
+    args+=("$url" "$dest")
+    if ! git "${args[@]}" 2>/dev/null; then
+      # Fallback: clone default branch shallow, then checkout ref
+      git clone --filter=blob:none --depth 1 "$url" "$dest"
+      if [[ -n "$ref" ]]; then
+        ( cd "$dest" && git fetch --depth 1 origin "$ref" && git checkout --detach FETCH_HEAD ) || true
+      fi
+    fi
+    return 0
+  fi
+  zpm_info "git not found; attempting tarball download"
+  zpm_fetch_tarball "$url" "$dest" "$ref"
+}
+
+zpm_update_repo() {
+  # dest [ref]
+  local dest="$1" ref="${2:-}"
+  if [[ -d "$dest/.git" ]] && zpm_git_available; then
+    (
+      cd "$dest"
+      git remote set-url origin "$(git remote get-url origin | sed 's/\n//g')" || true
+      git fetch --depth 1 --tags --prune origin
+      if [[ -n "$ref" ]]; then
+        if git rev-parse --verify --quiet "$ref" >/dev/null; then
+          git checkout --detach "$ref" || true
+        else
+          git checkout -B "$ref" "origin/${ref}" 2>/dev/null || git checkout --detach "origin/${ref}" || true
+        fi
+      else
+        local default_branch
+        default_branch=$(git symbolic-ref --short refs/remotes/origin/HEAD 2>/dev/null | sed 's@^origin/@@')
+        default_branch=${default_branch:-main}
+        git checkout -B "$default_branch" "origin/${default_branch}" || true
+      fi
+      git submodule update --init --depth 1 --recursive || true
+    )
+    return 0
+  fi
+  zpm_info "Non-git repo; re-fetching via tarball"
+  rm -rf "$dest" && mkdir -p "$dest"
+  zpm_fetch_tarball "$(zpm_guess_origin_url_from_path "$dest")" "$dest" "$ref"
+}
+
+zpm_guess_origin_url_from_path() {
+  # Best-effort: derive url when repo is at ZPM_REPOS_DIR/host/owner/name
+  local dest="$1"
+  local rel=${dest#"${ZPM_REPOS_DIR}/"}
+  local host=${rel%%/*}
+  local rest=${rel#*/}
+  local owner=${rest%%/*}
+  local name=${rest#*/}
+  echo "https://${host}/${owner}/${name}.git"
+}
+
+zpm_fetch_tarball() {
+  # url dest [ref]
+  local url="$1" dest="$2" ref="${3:-}"
+  require_cmd curl
+  require_cmd tar
+  # Only GitHub supported for fallback (common case)
+  local gh_pat='^https?://(www\.)?github\.com/([^/]+)/([^/.]+)(\.git)?'
+  if [[ "$url" =~ $gh_pat ]]; then
+    local owner="${BASH_REMATCH[2]}" name="${BASH_REMATCH[3]}"
+    local ref_or_default="${ref:-}"
+    if [[ -z "$ref_or_default" ]]; then
+      # Try to get default branch
+      if curl -fsSL "https://api.github.com/repos/${owner}/${name}" | grep -q 'default_branch'; then
+        ref_or_default=$(curl -fsSL "https://api.github.com/repos/${owner}/${name}" | sed -n 's/.*"default_branch": "\([^"]\+\)".*/\1/p' | head -n1)
+      else
+        ref_or_default=main
+      fi
+    fi
+    local tmp
+    tmp="$(mktempdir)"
+    local tarball_url="https://codeload.github.com/${owner}/${name}/tar.gz/${ref_or_default}"
+    zpm_debug "Downloading tarball ${tarball_url}"
+    curl -fsSL "$tarball_url" -o "${tmp}/repo.tgz"
+    mkdir -p "$dest"
+    tar -xzf "${tmp}/repo.tgz" -C "$tmp"
+    local extracted
+    extracted="$(find "$tmp" -maxdepth 1 -type d -name "${name}-*" | head -n1)"
+    if [[ -z "$extracted" ]]; then
+      die "Failed to extract tarball for ${owner}/${name}"
+    fi
+    rm -rf "$dest" && mkdir -p "$(dirname "$dest")"
+    mv "$extracted" "$dest"
+    return 0
+  fi
+  die "Tarball fallback currently supports github.com only (url: $url)"
+}

--- a/lib/zpm/locks.sh
+++ b/lib/zpm/locks.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# shellcheck shell=bash
+
+# Lock helpers: use flock when available, otherwise mkdir-based lock
+
+zpm_with_lock() {
+  # Usage: zpm_with_lock <name> -- <command> [args...]
+  local name="$1"; shift
+  if [[ "$1" != "--" ]]; then
+    die "zpm_with_lock requires -- separator"
+  fi
+  shift
+  local lockf="${ZPM_LOCKS_DIR}/${name}.lock"
+  mkdir -p "${ZPM_LOCKS_DIR}" || true
+  if is_command flock; then
+    # flock path
+    local fd
+    exec {fd}>"$lockf"
+    if ! flock -w "${ZPM_LOCK_TIMEOUT}" "$fd"; then
+      die "Failed to acquire lock: ${name} within ${ZPM_LOCK_TIMEOUT}s"
+    fi
+    "$@"
+    # Release
+    flock -u "$fd" || true
+    eval "exec ${fd}>&-" || true
+  else
+    # mkdir lock fallback
+    local acquired=0
+    local start="$(date +%s)"
+    while true; do
+      if mkdir "$lockf" 2>/dev/null; then
+        acquired=1; break
+      fi
+      sleep 0.2
+      local now="$(date +%s)"
+      if (( now - start >= ZPM_LOCK_TIMEOUT )); then
+        break
+      fi
+    done
+    if (( acquired == 0 )); then
+      die "Failed to acquire lock: ${name} within ${ZPM_LOCK_TIMEOUT}s"
+    fi
+    local rc=0
+    "$@" || rc=$?
+    rmdir "$lockf" 2>/dev/null || true
+    return $rc
+  fi
+}

--- a/lib/zpm/plugins.sh
+++ b/lib/zpm/plugins.sh
@@ -1,0 +1,145 @@
+#!/usr/bin/env bash
+# shellcheck shell=bash
+
+# Plugin specification parsing and install/update/list helpers
+
+# Parsed spec is returned via global variables for simplicity:
+# ZPM_SPEC_TYPE: git|local
+# ZPM_SPEC_URL: full URL for git
+# ZPM_SPEC_HOST, ZPM_SPEC_OWNER, ZPM_SPEC_NAME
+# ZPM_SPEC_REF: optional ref
+# ZPM_SPEC_PATH: for local type
+
+zpm_reset_spec_vars() {
+  ZPM_SPEC_TYPE=""; ZPM_SPEC_URL=""; ZPM_SPEC_HOST=""; ZPM_SPEC_OWNER=""; ZPM_SPEC_NAME=""; ZPM_SPEC_REF=""; ZPM_SPEC_PATH=""
+}
+
+zpm_parse_spec() {
+  # Accept forms:
+  # - owner/name[@ref]
+  # - gh:owner/name[@ref], github:owner/name[@ref]
+  # - https://github.com/owner/name(.git)[@ref]
+  # - git@github.com:owner/name.git[@ref]
+  # - ssh://git@host/owner/name.git[@ref]
+  # - /absolute/path or ./relative/path (local)
+  local spec="$1"
+  zpm_reset_spec_vars
+
+  # Local path
+  if [[ "$spec" == /* || "$spec" == ./* || "$spec" == ../* ]]; then
+    ZPM_SPEC_TYPE="local"; ZPM_SPEC_PATH="$(realpath -m "$spec")"; return 0
+  fi
+
+  local main="$spec" ref=""
+  if [[ "$spec" == *@* ]]; then
+    main="${spec%@*}"; ref="${spec#*@}"
+  fi
+
+  # gh: shorthand
+  if [[ "$main" == gh:* || "$main" == github:* ]]; then
+    local path="${main#*:}"
+    local owner="${path%%/*}" name="${path#*/}"
+    ZPM_SPEC_TYPE="git"
+    ZPM_SPEC_HOST="github.com"
+    ZPM_SPEC_OWNER="$owner"
+    ZPM_SPEC_NAME="$name"
+    ZPM_SPEC_REF="$ref"
+    ZPM_SPEC_URL="https://github.com/${owner}/${name}.git"
+    return 0
+  fi
+
+  # Full http(s) URL
+  if [[ "$main" =~ ^https?:// ]]; then
+    ZPM_SPEC_TYPE="git"
+    ZPM_SPEC_URL="$main"
+    # Attempt to extract host/owner/name if github-like
+    local gh_pat='^https?://([^/]+)/([^/]+)/([^/.]+)(\.git)?'
+    if [[ "$main" =~ $gh_pat ]]; then
+      ZPM_SPEC_HOST="${BASH_REMATCH[1]}"; ZPM_SPEC_OWNER="${BASH_REMATCH[2]}"; ZPM_SPEC_NAME="${BASH_REMATCH[3]}"
+    fi
+    ZPM_SPEC_REF="$ref"
+    return 0
+  fi
+
+  # SSH forms
+  if [[ "$main" =~ ^git@([^:]+):([^/]+)/([^/.]+)(\.git)?$ ]]; then
+    ZPM_SPEC_TYPE="git"
+    ZPM_SPEC_HOST="${BASH_REMATCH[1]}"; ZPM_SPEC_OWNER="${BASH_REMATCH[2]}"; ZPM_SPEC_NAME="${BASH_REMATCH[3]}"
+    ZPM_SPEC_URL="${main}"
+    ZPM_SPEC_REF="$ref"
+    return 0
+  fi
+  if [[ "$main" =~ ^ssh://[^/]+/([^/]+)/([^/.]+)(\.git)?$ ]]; then
+    ZPM_SPEC_TYPE="git"
+    ZPM_SPEC_HOST="unknown"; ZPM_SPEC_OWNER="${BASH_REMATCH[1]}"; ZPM_SPEC_NAME="${BASH_REMATCH[2]}"
+    ZPM_SPEC_URL="${main}"
+    ZPM_SPEC_REF="$ref"
+    return 0
+  fi
+
+  # owner/name (default github)
+  if [[ "$main" == */* ]]; then
+    local owner="${main%%/*}" name="${main#*/}"
+    ZPM_SPEC_TYPE="git"
+    ZPM_SPEC_HOST="github.com"
+    ZPM_SPEC_OWNER="$owner"
+    ZPM_SPEC_NAME="$name"
+    ZPM_SPEC_REF="$ref"
+    ZPM_SPEC_URL="https://github.com/${owner}/${name}.git"
+    return 0
+  fi
+
+  die "Invalid plugin spec: ${spec}"
+}
+
+zpm_install_one() {
+  local spec="$1"
+  zpm_parse_spec "$spec"
+  if [[ "$ZPM_SPEC_TYPE" == "local" ]]; then
+    zpm_info "Using local plugin: ${ZPM_SPEC_PATH}"
+    return 0
+  fi
+  local dest
+  dest="$(zpm_repo_path "${ZPM_SPEC_HOST:-unknown}" "${ZPM_SPEC_OWNER:-unknown}" "${ZPM_SPEC_NAME:-unknown}")"
+  if [[ -d "$dest" ]]; then
+    zpm_info "Already present: ${ZPM_SPEC_OWNER}/${ZPM_SPEC_NAME}"
+    return 0
+  fi
+  zpm_with_lock "${ZPM_SPEC_HOST}-${ZPM_SPEC_OWNER}-${ZPM_SPEC_NAME}" -- \
+    zpm_clone_shallow "${ZPM_SPEC_URL}" "$dest" "${ZPM_SPEC_REF:-}"
+  zpm_info "Installed: ${ZPM_SPEC_OWNER}/${ZPM_SPEC_NAME}${ZPM_SPEC_REF:+@$ZPM_SPEC_REF}"
+}
+
+zpm_update_one() {
+  local spec="$1"
+  zpm_parse_spec "$spec"
+  if [[ "$ZPM_SPEC_TYPE" == "local" ]]; then
+    zpm_info "Skipping local plugin (no update): ${ZPM_SPEC_PATH}"
+    return 0
+  fi
+  local dest
+  dest="$(zpm_repo_path "${ZPM_SPEC_HOST:-unknown}" "${ZPM_SPEC_OWNER:-unknown}" "${ZPM_SPEC_NAME:-unknown}")"
+  if [[ ! -d "$dest" ]]; then
+    zpm_info "Not installed, installing: ${ZPM_SPEC_OWNER}/${ZPM_SPEC_NAME}"
+    zpm_install_one "$spec"
+    return 0
+  fi
+  zpm_with_lock "${ZPM_SPEC_HOST}-${ZPM_SPEC_OWNER}-${ZPM_SPEC_NAME}" -- \
+    zpm_update_repo "$dest" "${ZPM_SPEC_REF:-}"
+  zpm_info "Updated: ${ZPM_SPEC_OWNER}/${ZPM_SPEC_NAME}${ZPM_SPEC_REF:+@$ZPM_SPEC_REF}"
+}
+
+zpm_list_installed() {
+  if [[ ! -d "$ZPM_REPOS_DIR" ]]; then return 0; fi
+  find "$ZPM_REPOS_DIR" -mindepth 3 -maxdepth 3 -type d -print 2>/dev/null | while read -r d; do
+    local rel=${d#"${ZPM_REPOS_DIR}/"}
+    echo "$rel"
+  done
+}
+
+zpm_plugins_from_file() {
+  local file="$1"
+  [[ -f "$file" ]] || die "Plugins file not found: $file"
+  # strip comments and blank lines
+  sed -e 's/#.*$//' -e '/^\s*$/d' "$file"
+}


### PR DESCRIPTION
Implement the core `zpm` Zsh plugin manager scaffold, including CLI commands and initial plugin lifecycle logic.

---
<a href="https://cursor.com/background-agent?bcId=bc-d2ff5f03-58a7-4b02-9f49-c5ec16de8784"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-d2ff5f03-58a7-4b02-9f49-c5ec16de8784"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

